### PR TITLE
온오프믹스 공모전, 해커톤 스크래퍼 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,3 +58,10 @@ CMD ["lambda_web_scraper.library_general_handler.handler"]
 FROM base AS wevity-contest
 COPY lambda_web_scraper/wevity_contest_handler.py ${LAMBDA_TASK_ROOT}/lambda_web_scraper/
 CMD ["lambda_web_scraper.wevity_contest_handler.handler"]
+
+# ====================
+# Stage 4: Onoffmix Contest Scraper
+# ====================
+FROM base AS onoffmix-contest
+COPY lambda_web_scraper/onoffmix_contest_handler.py ${LAMBDA_TASK_ROOT}/lambda_web_scraper/
+CMD ["lambda_web_scraper.onoffmix_contest_handler.handler"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,3 +65,10 @@ CMD ["lambda_web_scraper.wevity_contest_handler.handler"]
 FROM base AS onoffmix-contest
 COPY lambda_web_scraper/onoffmix_contest_handler.py ${LAMBDA_TASK_ROOT}/lambda_web_scraper/
 CMD ["lambda_web_scraper.onoffmix_contest_handler.handler"]
+
+# ====================
+# Stage 5: Onoffmix Hackathon Scraper
+# ====================
+FROM base AS onoffmix-hackathon
+COPY lambda_web_scraper/onoffmix_hackathon_handler.py ${LAMBDA_TASK_ROOT}/lambda_web_scraper/
+CMD ["lambda_web_scraper.onoffmix_hackathon_handler.handler"]

--- a/common_utils.py
+++ b/common_utils.py
@@ -178,3 +178,82 @@ def send_common_utils_error_notification(
         message += f"\n*추가 정보:* {additional_info}"
 
     return send_slack_notification(message, f"common_utils_{method_name}")
+
+
+# ===== 공통 스크래핑 유틸 =====
+def setup_playwright_browser():
+    """Playwright 브라우저/페이지 공통 설정"""
+    try:
+        from playwright.sync_api import sync_playwright
+
+        p = sync_playwright().start()
+        browser = p.chromium.launch(
+            headless=True,
+            args=[
+                "--no-sandbox",
+                "--disable-setuid-sandbox",
+                "--disable-dev-shm-usage",
+                "--disable-accelerated-2d-canvas",
+                "--no-first-run",
+                "--no-zygote",
+                "--single-process",
+                "--disable-gpu",
+                "--disable-background-timer-throttling",
+                "--disable-backgrounding-occluded-windows",
+                "--disable-renderer-backgrounding",
+                "--disable-web-security",
+                "--disable-features=TranslateUI",
+                "--disable-extensions",
+            ],
+        )
+
+        page = browser.new_page()
+        page.set_extra_http_headers(
+            {
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+            }
+        )
+
+        return p, browser, page
+    except Exception as e:
+        error_msg = f"Playwright 브라우저 설정 실패: {e}"
+        print(f"❌ [SCRAPER] {error_msg}")
+        raise
+
+
+def get_recent_title_link_sets(collection_name: str):
+    """최근 공지에서 제목/링크 세트와 원본 리스트를 함께 반환"""
+    recent = get_recent_notices(collection_name)
+    recent_titles = {n.get("title") for n in recent}
+    recent_links = {n.get("link") for n in recent}
+    return recent_titles, recent_links, recent
+
+
+def _parse_iso_datetime(dt_str: str) -> datetime:
+    """ISO 문자열을 datetime으로 안전하게 파싱 (Z 처리 포함)"""
+    try:
+        if not dt_str:
+            return datetime.now()
+        normalized = dt_str.replace("Z", "+00:00")
+        return datetime.fromisoformat(normalized)
+    except Exception:
+        return datetime.now()
+
+
+def is_within_days(published_iso_str: str, days: int, tz) -> bool:
+    """발행일이 최근 N일 이내인지 여부"""
+    try:
+        published_dt = _parse_iso_datetime(published_iso_str)
+        if tz is not None and published_dt.tzinfo is None:
+            # naive -> 지정된 타임존 로컬라이즈
+            try:
+                published_dt = tz.localize(published_dt)
+            except Exception:
+                pass
+        threshold = (
+            datetime.now(tz) if tz is not None else datetime.now()
+        ) - timedelta(days=days)
+        return published_dt >= threshold
+    except Exception:
+        # 파싱 오류 시 보수적으로 포함 처리
+        return True

--- a/lambda_web_scraper/library_general_handler.py
+++ b/lambda_web_scraper/library_general_handler.py
@@ -3,7 +3,14 @@ from datetime import datetime, timedelta
 from typing import Dict, Any
 import pytz
 
-from common_utils import get_recent_notices, save_notices_to_db, send_slack_notification
+from common_utils import (
+    get_recent_notices,
+    save_notices_to_db,
+    send_slack_notification,
+    setup_playwright_browser,
+    get_recent_title_link_sets,
+    is_within_days,
+)
 
 
 def parse_date(date_str: str, kst: pytz.timezone) -> datetime:
@@ -28,38 +35,8 @@ def parse_date(date_str: str, kst: pytz.timezone) -> datetime:
 
 
 def _setup_browser():
-    """브라우저 설정 및 페이지 생성"""
-    from playwright.sync_api import sync_playwright
-
-    p = sync_playwright().start()
-    browser = p.chromium.launch(
-        headless=True,
-        args=[
-            "--no-sandbox",
-            "--disable-setuid-sandbox",
-            "--disable-dev-shm-usage",
-            "--disable-accelerated-2d-canvas",
-            "--no-first-run",
-            "--no-zygote",
-            "--single-process",
-            "--disable-gpu",
-            "--disable-background-timer-throttling",
-            "--disable-backgrounding-occluded-windows",
-            "--disable-renderer-backgrounding",
-            "--disable-web-security",
-            "--disable-features=TranslateUI",
-            "--disable-extensions",
-        ],
-    )
-
-    page = browser.new_page()
-    page.set_extra_http_headers(
-        {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-        }
-    )
-
-    return p, browser, page
+    """브라우저 설정 및 페이지 생성 (공통 유틸 사용)"""
+    return setup_playwright_browser()
 
 
 def _navigate_to_main_page(page, url):
@@ -160,13 +137,8 @@ def _process_single_notice(page, row, index, url, recent_titles, recent_links, k
             published = _extract_date_from_detail_page(page, kst)
             notice_data = _create_notice_data(title, actual_link, published)
 
-            # 30일 이내 필터링
-            thirty_days_ago = datetime.now(kst) - timedelta(days=30)
-            published_date = datetime.fromisoformat(
-                notice_data["published"].replace("Z", "+00:00")
-            )
-
-            if published_date >= thirty_days_ago:
+            # 30일 이내 필터링 (공통 유틸 사용)
+            if is_within_days(notice_data["published"], 30, kst):
                 print(f"🆕 [SCRAPER] 새로운 공지사항 추가: {title[:30]}...")
                 return notice_data
             else:
@@ -227,10 +199,10 @@ def scrape_library_general() -> Dict[str, Any]:
                     "body": {"message": "공지사항을 찾을 수 없음"},
                 }
 
-            # 기존 공지사항 확인
-            recent_notices = get_recent_notices("library_general")
-            recent_links = {notice.get("link") for notice in recent_notices}
-            recent_titles = {notice.get("title") for notice in recent_notices}
+            # 기존 공지사항 확인 (공통 유틸 사용)
+            recent_titles, recent_links, recent_notices = get_recent_title_link_sets(
+                "library_general"
+            )
             print(f"📋 [DB] 기존 공지사항 수: {len(recent_notices)}")
 
             # 각 공지사항 처리

--- a/lambda_web_scraper/onoffmix_contest_handler.py
+++ b/lambda_web_scraper/onoffmix_contest_handler.py
@@ -57,6 +57,17 @@ def _get_event_items(page: Any) -> List[Any]:
     return items
 
 
+def _is_ad_item(item: Any) -> bool:
+    """
+    광고 공고는 `article.event_area.event_main.adv_list` 클래스를 가짐.
+    해당 항목은 스크래핑 대상에서 제외한다.
+    """
+    try:
+        return item.query_selector("article.event_area.event_main.adv_list") is not None
+    except Exception:
+        return False
+
+
 def _is_ended(item: Any) -> bool:
     # 활성 상태가 명시된 경우 우선적으로 종료 아님 처리
     try:
@@ -153,6 +164,10 @@ def _process_single_event(
 ) -> Optional[Dict[str, Any]]:
     try:
         print(f"🔍 [SCRAPER] 이벤트 {index+1} 처리 시작")
+
+        if _is_ad_item(item):
+            print(f"🪧 [SCRAPER] 광고 항목 (스킵): index={index+1}")
+            return None
 
         if _is_ended(item):
             print(f"⛔ [SCRAPER] 종료된 이벤트 (스킵): index={index+1}")

--- a/lambda_web_scraper/onoffmix_contest_handler.py
+++ b/lambda_web_scraper/onoffmix_contest_handler.py
@@ -3,7 +3,14 @@ from datetime import datetime, timedelta
 from typing import Dict, Any, Optional, Tuple, List
 import pytz
 
-from common_utils import get_recent_notices, save_notices_to_db, send_slack_notification
+from common_utils import (
+    get_recent_notices,
+    save_notices_to_db,
+    send_slack_notification,
+    setup_playwright_browser,
+    get_recent_title_link_sets,
+    is_within_days,
+)
 
 
 def parse_deadline_text(deadline_text: str, kst: pytz.timezone) -> datetime:
@@ -34,37 +41,7 @@ def parse_deadline_text(deadline_text: str, kst: pytz.timezone) -> datetime:
 
 
 def _setup_browser() -> Tuple[Any, Any, Any]:
-    from playwright.sync_api import sync_playwright
-
-    p = sync_playwright().start()
-    browser = p.chromium.launch(
-        headless=True,
-        args=[
-            "--no-sandbox",
-            "--disable-setuid-sandbox",
-            "--disable-dev-shm-usage",
-            "--disable-accelerated-2d-canvas",
-            "--no-first-run",
-            "--no-zygote",
-            "--single-process",
-            "--disable-gpu",
-            "--disable-background-timer-throttling",
-            "--disable-backgrounding-occluded-windows",
-            "--disable-renderer-backgrounding",
-            "--disable-web-security",
-            "--disable-features=TranslateUI",
-            "--disable-extensions",
-        ],
-    )
-
-    page = browser.new_page()
-    page.set_extra_http_headers(
-        {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-        }
-    )
-
-    return p, browser, page
+    return setup_playwright_browser()
 
 
 def _navigate_to_main_page(page: Any, url: str) -> None:
@@ -207,11 +184,7 @@ def _process_single_event(
 
         notice = _create_notice_data(title, link, published)
 
-        thirty_days_ago = datetime.now(kst) - timedelta(days=30)
-        published_date = datetime.fromisoformat(
-            notice["published"].replace("Z", "+00:00")
-        )
-        if published_date >= thirty_days_ago:
+        if is_within_days(notice["published"], 30, kst):
             print(f"🆕 [SCRAPER] 새로운 이벤트 추가: {title[:30]}...")
             return notice
         else:
@@ -239,7 +212,7 @@ def scrape_onoffmix_contest() -> Dict[str, Any]:
                 print("❌ [SCRAPER] 이벤트 항목을 찾을 수 없음")
                 return {"success": False, "error": "이벤트 항목을 찾을 수 없음"}
 
-            recent = get_recent_notices("onoffmix_contest")
+            _, _, recent = get_recent_title_link_sets("onoffmix_contest")
             recent_links = {n.get("link") for n in recent}
             recent_titles = {n.get("title") for n in recent}
             print(f"📋 [DB] 기존 온오프믹스 공모전 수: {len(recent)}")

--- a/lambda_web_scraper/onoffmix_contest_handler.py
+++ b/lambda_web_scraper/onoffmix_contest_handler.py
@@ -1,0 +1,294 @@
+import re
+from datetime import datetime, timedelta
+from typing import Dict, Any, Optional, Tuple, List
+import pytz
+
+from common_utils import get_recent_notices, save_notices_to_db, send_slack_notification
+
+
+def parse_deadline_text(deadline_text: str, kst: pytz.timezone) -> datetime:
+    """
+    온오프믹스 리스트의 "마감 X전" 정보를 기반으로 마감 예상일을 계산.
+    지원 단위: 시간, 일, 주, 달
+    """
+    try:
+        text = deadline_text.strip()
+        number_match = re.search(r"(\d+)", text)
+        if not number_match:
+            return datetime.now(kst)
+
+        amount = int(number_match.group(1))
+        if "시간" in text:
+            return datetime.now(kst) + timedelta(hours=amount)
+        if "일" in text:
+            return datetime.now(kst) + timedelta(days=amount)
+        if "주" in text:
+            return datetime.now(kst) + timedelta(weeks=amount)
+        if "달" in text or "개월" in text:
+            return datetime.now(kst) + timedelta(days=30 * amount)
+
+        return datetime.now(kst)
+    except Exception as e:
+        print(f"⚠️ [PARSER] 마감일 파싱 실패: {deadline_text}, 오류: {e}")
+        return datetime.now(kst)
+
+
+def _setup_browser() -> Tuple[Any, Any, Any]:
+    from playwright.sync_api import sync_playwright
+
+    p = sync_playwright().start()
+    browser = p.chromium.launch(
+        headless=True,
+        args=[
+            "--no-sandbox",
+            "--disable-setuid-sandbox",
+            "--disable-dev-shm-usage",
+            "--disable-accelerated-2d-canvas",
+            "--no-first-run",
+            "--no-zygote",
+            "--single-process",
+            "--disable-gpu",
+            "--disable-background-timer-throttling",
+            "--disable-backgrounding-occluded-windows",
+            "--disable-renderer-backgrounding",
+            "--disable-web-security",
+            "--disable-features=TranslateUI",
+            "--disable-extensions",
+        ],
+    )
+
+    page = browser.new_page()
+    page.set_extra_http_headers(
+        {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+        }
+    )
+
+    return p, browser, page
+
+
+def _navigate_to_main_page(page: Any, url: str) -> None:
+    page.goto(url, timeout=30000)
+    page.wait_for_selector("ul.event_lists", timeout=10000)
+    page.wait_for_timeout(1500)
+
+
+def _get_event_items(page: Any) -> List[Any]:
+    items = page.query_selector_all("ul.event_lists > li")
+    items = items[:20]
+    print(f"📊 [SCRAPER] 발견된 이벤트 수: {len(items)} (최신 20개만 처리)")
+    return items
+
+
+def _is_ended(item: Any) -> bool:
+    # 활성 상태가 명시된 경우 우선적으로 종료 아님 처리
+    try:
+        if item.query_selector(".event_state_area .before_closing"):
+            return False
+    except Exception:
+        pass
+
+    end_txt = item.query_selector("p.end_txt")
+    if not end_txt:
+        return False
+
+    # 요소의 실제 가시성 체크 (숨김 상태면 종료로 보지 않음)
+    try:
+        is_visible = end_txt.evaluate(
+            """
+            el => {
+                const style = getComputedStyle(el);
+                const visible = style.visibility !== 'hidden' && style.display !== 'none';
+                const inFlow = !!(el.offsetParent || el.getClientRects().length);
+                return visible && inFlow;
+            }
+            """
+        )
+    except Exception:
+        is_visible = True
+
+    if not is_visible:
+        return False
+
+    try:
+        txt = end_txt.text_content().strip()
+    except Exception:
+        txt = ""
+
+    return ("종료된 이벤트입니다" in txt) or ("종료" in txt)
+
+
+def _extract_title_from_item(item: Any, index: int) -> Optional[Tuple[str, Any]]:
+    article = item.query_selector("article.event_area.event_main")
+    if not article:
+        print(f"⚠️ [SCRAPER] 항목 {index+1}에서 article 요소 없음")
+        return None
+    title_el = article.query_selector("h5.title")
+    if not title_el:
+        print(f"⚠️ [SCRAPER] 항목 {index+1}에서 제목 요소 없음")
+        return None
+    title = title_el.evaluate("el => el.textContent").strip()
+    print(f"📰 [SCRAPER] 제목: '{title}'")
+    return title, article
+
+
+def _extract_link_from_item(article: Any, index: int) -> Optional[str]:
+    link_el = article.query_selector("a")
+    if not link_el:
+        print(f"⚠️ [SCRAPER] 항목 {index+1} 링크 요소 없음")
+        return None
+    href = link_el.get_attribute("href")
+    if not href:
+        return None
+    if href.startswith("/"):
+        href = f"https://onoffmix.com{href}"
+    print(f"🔗 [SCRAPER] 링크: '{href}'")
+    return href
+
+
+def _extract_deadline_from_item(article: Any, index: int) -> Optional[str]:
+    day_el = article.query_selector(".event_state_area .before_closing .day")
+    if day_el:
+        day_text = day_el.text_content().strip()
+        print(f"📅 [SCRAPER] 마감까지: '{day_text}'")
+        return day_text
+    # 대체: 리스트의 날짜 텍스트 (가공은 어렵기에 로그만 남김)
+    date_el = article.query_selector(".list_date_place .date, .event_info .date")
+    if date_el:
+        alt_text = date_el.text_content().strip()
+        print(f"📅 [SCRAPER] 대체 날짜 정보: '{alt_text}'")
+    return None
+
+
+def _create_notice_data(
+    title: str, link: str, published_date: datetime
+) -> Dict[str, Any]:
+    return {
+        "title": title,
+        "link": link,
+        "published": published_date.isoformat(),
+        "scraper_type": "onoffmix_contest",
+    }
+
+
+def _process_single_event(
+    item: Any, index: int, recent_titles: set, recent_links: set, kst: pytz.timezone
+) -> Optional[Dict[str, Any]]:
+    try:
+        print(f"🔍 [SCRAPER] 이벤트 {index+1} 처리 시작")
+
+        if _is_ended(item):
+            print(f"⛔ [SCRAPER] 종료된 이벤트 (스킵): index={index+1}")
+            return None
+
+        title_info = _extract_title_from_item(item, index)
+        if not title_info:
+            return None
+        title, article = title_info
+
+        if title in recent_titles:
+            print(f"♻️ [SCRAPER] 기존 제목 (스킵): {title[:30]}...")
+            return None
+
+        link = _extract_link_from_item(article, index)
+        if not link:
+            return None
+
+        if link in recent_links:
+            print(f"♻️ [SCRAPER] 기존 링크 (스킵): {link}")
+            return None
+
+        deadline_text = _extract_deadline_from_item(article, index)
+        published = (
+            parse_deadline_text(deadline_text, kst)
+            if deadline_text
+            else datetime.now(kst)
+        )
+
+        notice = _create_notice_data(title, link, published)
+
+        thirty_days_ago = datetime.now(kst) - timedelta(days=30)
+        published_date = datetime.fromisoformat(
+            notice["published"].replace("Z", "+00:00")
+        )
+        if published_date >= thirty_days_ago:
+            print(f"🆕 [SCRAPER] 새로운 이벤트 추가: {title[:30]}...")
+            return notice
+        else:
+            print(f"⏰ [SCRAPER] 30일 이전 데이터 제외: {title[:30]}...")
+            return None
+    except Exception as e:
+        print(f"⚠️ [SCRAPER] 이벤트 {index+1} 처리 중 오류: {e}")
+        return None
+
+
+def scrape_onoffmix_contest() -> Dict[str, Any]:
+    url = "https://onoffmix.com/event/main/?c=105"
+    kst = pytz.timezone("Asia/Seoul")
+    print(f"🌐 [SCRAPER] 스크래핑 시작 - URL: {url}")
+
+    try:
+        p, browser, page = _setup_browser()
+        new_notices: List[Dict[str, Any]] = []
+
+        try:
+            _navigate_to_main_page(page, url)
+            items = _get_event_items(page)
+
+            if not items:
+                print("❌ [SCRAPER] 이벤트 항목을 찾을 수 없음")
+                return {"success": False, "error": "이벤트 항목을 찾을 수 없음"}
+
+            recent = get_recent_notices("onoffmix_contest")
+            recent_links = {n.get("link") for n in recent}
+            recent_titles = {n.get("title") for n in recent}
+            print(f"📋 [DB] 기존 온오프믹스 공모전 수: {len(recent)}")
+
+            for i in range(len(items)):
+                current_items = page.query_selector_all("ul.event_lists > li")
+                if i >= len(current_items):
+                    print(f"⚠️ [SCRAPER] 이벤트 {i+1} 인덱스 초과")
+                    continue
+                item = current_items[i]
+                notice = _process_single_event(
+                    item, i, recent_titles, recent_links, kst
+                )
+                if notice:
+                    new_notices.append(notice)
+        finally:
+            browser.close()
+            p.stop()
+
+        print(f"📈 [SCRAPER] 새로운 온오프믹스 공모전 수: {len(new_notices)}")
+        saved_count = 0
+        if new_notices:
+            saved_count = save_notices_to_db(new_notices, "onoffmix_contest")
+            print(f"💾 [SCRAPER] 저장 완료: {saved_count}개")
+
+        result = {
+            "success": True,
+            "message": "온오프믹스 공모전 스크래핑 완료",
+            "total_found": len(items),
+            "new_notices_count": len(new_notices),
+            "saved_count": saved_count,
+            "new_notices": new_notices,
+        }
+        print("🎉 [SCRAPER] 스크래핑 완료")
+        return result
+    except Exception as e:
+        error_msg = f"스크래핑 중 오류: {str(e)}"
+        print(f"❌ [SCRAPER] {error_msg}")
+        send_slack_notification(error_msg, "onoffmix_contest")
+        return {"success": False, "error": error_msg}
+
+
+def handler(event, context):
+    print("🚀 [HANDLER] Lambda Handler 시작 (onoffmix)")
+    try:
+        scrape_onoffmix_contest()
+        return {"statusCode": 200}
+    except Exception as e:
+        error_msg = f"Lambda Handler 실행 중 오류: {str(e)}"
+        print(f"❌ [HANDLER] {error_msg}")
+        send_slack_notification(error_msg, "onoffmix_contest")
+        return {"statusCode": 500}

--- a/lambda_web_scraper/onoffmix_hackathon_handler.py
+++ b/lambda_web_scraper/onoffmix_hackathon_handler.py
@@ -1,0 +1,282 @@
+import re
+from datetime import datetime, timedelta
+from typing import Dict, Any, Optional, Tuple, List
+import pytz
+
+from common_utils import (
+    get_recent_notices,
+    save_notices_to_db,
+    send_slack_notification,
+    setup_playwright_browser,
+    get_recent_title_link_sets,
+    is_within_days,
+)
+
+
+def parse_deadline_text(deadline_text: str, kst: pytz.timezone) -> datetime:
+    """
+    온오프믹스 리스트의 "마감 X전" 정보를 기반으로 마감 예상일을 계산.
+    지원 단위: 시간, 일, 주, 달
+    """
+    try:
+        text = deadline_text.strip()
+        number_match = re.search(r"(\d+)", text)
+        if not number_match:
+            return datetime.now(kst)
+
+        amount = int(number_match.group(1))
+        if "시간" in text:
+            return datetime.now(kst) + timedelta(hours=amount)
+        if "일" in text:
+            return datetime.now(kst) + timedelta(days=amount)
+        if "주" in text:
+            return datetime.now(kst) + timedelta(weeks=amount)
+        if "달" in text or "개월" in text:
+            return datetime.now(kst) + timedelta(days=30 * amount)
+
+        return datetime.now(kst)
+    except Exception as e:
+        print(f"⚠️ [PARSER] 마감일 파싱 실패: {deadline_text}, 오류: {e}")
+        return datetime.now(kst)
+
+
+def _setup_browser() -> Tuple[Any, Any, Any]:
+    return setup_playwright_browser()
+
+
+def _navigate_to_main_page(page: Any, url: str) -> None:
+    page.goto(url, timeout=30000)
+    page.wait_for_selector("ul.event_lists", timeout=10000)
+    page.wait_for_timeout(1500)
+
+
+def _get_event_items(page: Any) -> List[Any]:
+    items = page.query_selector_all("ul.event_lists > li")
+    items = items[:20]
+    print(f"📊 [SCRAPER] 발견된 이벤트 수: {len(items)} (최신 20개만 처리)")
+    return items
+
+
+def _is_ad_item(item: Any) -> bool:
+    """
+    광고 공고는 `article.event_area.event_main.adv_list` 클래스를 가짐.
+    해당 항목은 스크래핑 대상에서 제외한다.
+    """
+    try:
+        return item.query_selector("article.event_area.event_main.adv_list") is not None
+    except Exception:
+        return False
+
+
+def _is_ended(item: Any) -> bool:
+    # 활성 상태가 명시된 경우 우선적으로 종료 아님 처리
+    try:
+        if item.query_selector(".event_state_area .before_closing"):
+            return False
+    except Exception:
+        pass
+
+    end_txt = item.query_selector("p.end_txt")
+    if not end_txt:
+        return False
+
+    # 요소의 실제 가시성 체크 (숨김 상태면 종료로 보지 않음)
+    try:
+        is_visible = end_txt.evaluate(
+            """
+            el => {
+                const style = getComputedStyle(el);
+                const visible = style.visibility !== 'hidden' && style.display !== 'none';
+                const inFlow = !!(el.offsetParent || el.getClientRects().length);
+                return visible && inFlow;
+            }
+            """
+        )
+    except Exception:
+        is_visible = True
+
+    if not is_visible:
+        return False
+
+    try:
+        txt = end_txt.text_content().strip()
+    except Exception:
+        txt = ""
+
+    return ("종료된 이벤트입니다" in txt) or ("종료" in txt)
+
+
+def _extract_title_from_item(item: Any, index: int) -> Optional[Tuple[str, Any]]:
+    article = item.query_selector("article.event_area.event_main")
+    if not article:
+        print(f"⚠️ [SCRAPER] 항목 {index+1}에서 article 요소 없음")
+        return None
+    title_el = article.query_selector("h5.title")
+    if not title_el:
+        print(f"⚠️ [SCRAPER] 항목 {index+1}에서 제목 요소 없음")
+        return None
+    title = title_el.evaluate("el => el.textContent").strip()
+    print(f"📰 [SCRAPER] 제목: '{title}'")
+    return title, article
+
+
+def _extract_link_from_item(article: Any, index: int) -> Optional[str]:
+    link_el = article.query_selector("a")
+    if not link_el:
+        print(f"⚠️ [SCRAPER] 항목 {index+1} 링크 요소 없음")
+        return None
+    href = link_el.get_attribute("href")
+    if not href:
+        return None
+    if href.startswith("/"):
+        href = f"https://onoffmix.com{href}"
+    print(f"🔗 [SCRAPER] 링크: '{href}'")
+    return href
+
+
+def _extract_deadline_from_item(article: Any, index: int) -> Optional[str]:
+    day_el = article.query_selector(".event_state_area .before_closing .day")
+    if day_el:
+        day_text = day_el.text_content().strip()
+        print(f"📅 [SCRAPER] 마감까지: '{day_text}'")
+        return day_text
+    # 대체: 리스트의 날짜 텍스트 (가공은 어렵기에 로그만 남김)
+    date_el = article.query_selector(".list_date_place .date, .event_info .date")
+    if date_el:
+        alt_text = date_el.text_content().strip()
+        print(f"📅 [SCRAPER] 대체 날짜 정보: '{alt_text}'")
+    return None
+
+
+def _create_notice_data(
+    title: str, link: str, published_date: datetime
+) -> Dict[str, Any]:
+    return {
+        "title": title,
+        "link": link,
+        "published": published_date.isoformat(),
+        "scraper_type": "onoffmix_hackathon",
+    }
+
+
+def _process_single_event(
+    item: Any, index: int, recent_titles: set, recent_links: set, kst: pytz.timezone
+) -> Optional[Dict[str, Any]]:
+    try:
+        print(f"🔍 [SCRAPER] 이벤트 {index+1} 처리 시작")
+
+        if _is_ad_item(item):
+            print(f"🪧 [SCRAPER] 광고 항목 (스킵): index={index+1}")
+            return None
+
+        if _is_ended(item):
+            print(f"⛔ [SCRAPER] 종료된 이벤트 (스킵): index={index+1}")
+            return None
+
+        title_info = _extract_title_from_item(item, index)
+        if not title_info:
+            return None
+        title, article = title_info
+
+        if title in recent_titles:
+            print(f"♻️ [SCRAPER] 기존 제목 (스킵): {title[:30]}...")
+            return None
+
+        link = _extract_link_from_item(article, index)
+        if not link:
+            return None
+
+        if link in recent_links:
+            print(f"♻️ [SCRAPER] 기존 링크 (스킵): {link}")
+            return None
+
+        deadline_text = _extract_deadline_from_item(article, index)
+        published = (
+            parse_deadline_text(deadline_text, kst)
+            if deadline_text
+            else datetime.now(kst)
+        )
+
+        notice = _create_notice_data(title, link, published)
+
+        if is_within_days(notice["published"], 30, kst):
+            print(f"🆕 [SCRAPER] 새로운 이벤트 추가: {title[:30]}...")
+            return notice
+        else:
+            print(f"⏰ [SCRAPER] 30일 이전 데이터 제외: {title[:30]}...")
+            return None
+    except Exception as e:
+        print(f"⚠️ [SCRAPER] 이벤트 {index+1} 처리 중 오류: {e}")
+        return None
+
+
+def scrape_onoffmix_hackathon() -> Dict[str, Any]:
+    url = "https://onoffmix.com/event/main?s=%ED%95%B4%EC%BB%A4%ED%86%A4"
+    kst = pytz.timezone("Asia/Seoul")
+    print(f"🌐 [SCRAPER] 스크래핑 시작 - URL: {url}")
+
+    try:
+        p, browser, page = _setup_browser()
+        new_notices: List[Dict[str, Any]] = []
+
+        try:
+            _navigate_to_main_page(page, url)
+            items = _get_event_items(page)
+
+            if not items:
+                print("❌ [SCRAPER] 이벤트 항목을 찾을 수 없음")
+                return {"success": False, "error": "이벤트 항목을 찾을 수 없음"}
+
+            _, _, recent = get_recent_title_link_sets("onoffmix_hackathon")
+            recent_links = {n.get("link") for n in recent}
+            recent_titles = {n.get("title") for n in recent}
+            print(f"📋 [DB] 기존 온오프믹스 해커톤 수: {len(recent)}")
+
+            for i in range(len(items)):
+                current_items = page.query_selector_all("ul.event_lists > li")
+                if i >= len(current_items):
+                    print(f"⚠️ [SCRAPER] 이벤트 {i+1} 인덱스 초과")
+                    continue
+                item = current_items[i]
+                notice = _process_single_event(
+                    item, i, recent_titles, recent_links, kst
+                )
+                if notice:
+                    new_notices.append(notice)
+        finally:
+            browser.close()
+            p.stop()
+
+        print(f"📈 [SCRAPER] 새로운 온오프믹스 해커톤 수: {len(new_notices)}")
+        saved_count = 0
+        if new_notices:
+            saved_count = save_notices_to_db(new_notices, "onoffmix_hackathon")
+            print(f"💾 [SCRAPER] 저장 완료: {saved_count}개")
+
+        result = {
+            "success": True,
+            "message": "온오프믹스 해커톤 스크래핑 완료",
+            "total_found": len(items),
+            "new_notices_count": len(new_notices),
+            "saved_count": saved_count,
+            "new_notices": new_notices,
+        }
+        print("🎉 [SCRAPER] 스크래핑 완료")
+        return result
+    except Exception as e:
+        error_msg = f"스크래핑 중 오류: {str(e)}"
+        print(f"❌ [SCRAPER] {error_msg}")
+        send_slack_notification(error_msg, "onoffmix_hackathon")
+        return {"success": False, "error": error_msg}
+
+
+def handler(event, context):
+    print("🚀 [HANDLER] Lambda Handler 시작 (onoffmix_hackathon)")
+    try:
+        scrape_onoffmix_hackathon()
+        return {"statusCode": 200}
+    except Exception as e:
+        error_msg = f"Lambda Handler 실행 중 오류: {str(e)}"
+        print(f"❌ [HANDLER] {error_msg}")
+        send_slack_notification(error_msg, "onoffmix_hackathon")
+        return {"statusCode": 500}

--- a/lambda_web_scraper/wevity_contest_handler.py
+++ b/lambda_web_scraper/wevity_contest_handler.py
@@ -3,7 +3,14 @@ from datetime import datetime, timedelta
 from typing import Dict, Any
 import pytz
 
-from common_utils import get_recent_notices, save_notices_to_db, send_slack_notification
+from common_utils import (
+    get_recent_notices,
+    save_notices_to_db,
+    send_slack_notification,
+    setup_playwright_browser,
+    get_recent_title_link_sets,
+    is_within_days,
+)
 
 
 def parse_date(date_str: str, kst: pytz.timezone) -> datetime:
@@ -26,38 +33,8 @@ def parse_date(date_str: str, kst: pytz.timezone) -> datetime:
 
 
 def _setup_browser():
-    """브라우저 설정 및 페이지 생성"""
-    from playwright.sync_api import sync_playwright
-
-    p = sync_playwright().start()
-    browser = p.chromium.launch(
-        headless=True,
-        args=[
-            "--no-sandbox",
-            "--disable-setuid-sandbox",
-            "--disable-dev-shm-usage",
-            "--disable-accelerated-2d-canvas",
-            "--no-first-run",
-            "--no-zygote",
-            "--single-process",
-            "--disable-gpu",
-            "--disable-background-timer-throttling",
-            "--disable-backgrounding-occluded-windows",
-            "--disable-renderer-backgrounding",
-            "--disable-web-security",
-            "--disable-features=TranslateUI",
-            "--disable-extensions",
-        ],
-    )
-
-    page = browser.new_page()
-    page.set_extra_http_headers(
-        {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-        }
-    )
-
-    return p, browser, page
+    """브라우저 설정 및 페이지 생성 (공통 유틸 사용)"""
+    return setup_playwright_browser()
 
 
 def _navigate_to_main_page(page, url):
@@ -164,13 +141,8 @@ def _process_single_contest(item, index, recent_titles, recent_links, kst):
 
         contest_data = _create_contest_data(title, link, published)
 
-        # 30일 이내 필터링 (published 기준)
-        thirty_days_ago = datetime.now(kst) - timedelta(days=30)
-        published_date = datetime.fromisoformat(
-            contest_data["published"].replace("Z", "+00:00")
-        )
-
-        if published_date >= thirty_days_ago:
+        # 30일 이내 필터링 (공통 유틸 사용)
+        if is_within_days(contest_data["published"], 30, kst):
             print(f"🆕 [SCRAPER] 새로운 공모전 추가: {title[:30]}...")
             return contest_data
         else:
@@ -206,10 +178,10 @@ def scrape_wevity_contest() -> Dict[str, Any]:
                     "error": "공모전 항목을 찾을 수 없음",
                 }
 
-            # 기존 공모전 확인
-            recent_notices = get_recent_notices("wevity_contest")
-            recent_links = {notice.get("link") for notice in recent_notices}
-            recent_titles = {notice.get("title") for notice in recent_notices}
+            # 기존 공모전 확인 (공통 유틸 사용)
+            recent_titles, recent_links, recent_notices = get_recent_title_link_sets(
+                "wevity_contest"
+            )
             print(f"📋 [DB] 기존 공모전 수: {len(recent_notices)}")
 
             # 각 공모전 처리

--- a/metadata/scraper_categories.json
+++ b/metadata/scraper_categories.json
@@ -142,7 +142,8 @@
         "OFFCAMPUS_CONTEST_CATEGORY": {
             "korean_name": "외부 대회 및 공모전",
             "scraper_types": [
-                "WEVITY_CONTEST"
+                "WEVITY_CONTEST",
+                "ONOFFMIX_CONTEST"
             ]
         }
     }

--- a/metadata/scraper_categories.json
+++ b/metadata/scraper_categories.json
@@ -143,7 +143,8 @@
             "korean_name": "외부 대회 및 공모전",
             "scraper_types": [
                 "WEVITY_CONTEST",
-                "ONOFFMIX_CONTEST"
+                "ONOFFMIX_CONTEST",
+                "ONOFFMIX_HACKATHON"
             ]
         }
     }

--- a/metadata/scraper_types.json
+++ b/metadata/scraper_types.json
@@ -343,6 +343,13 @@
             "scraper_class_name": "UniversityThursdaylectureScraper",
             "scraper_lambda_function_name": "university_thursdaylecture_scraper"
         },
+        "ONOFFMIX_CONTEST": {
+            "type_name": "ONOFFMIX_CONTEST",
+            "korean_name": "온오프믹스 공모전 공지",
+            "url": "https://onoffmix.com/event/main/?c=105",
+            "scraper_class_name": "OnoffmixContestScraper",
+            "scraper_lambda_function_name": "onoffmix_contest_scraper"
+        },
         "WEVITY_CONTEST": {
             "type_name": "WEVITY_CONTEST",
             "korean_name": "위비티 공모전 공지",

--- a/metadata/scraper_types.json
+++ b/metadata/scraper_types.json
@@ -350,6 +350,13 @@
             "scraper_class_name": "OnoffmixContestScraper",
             "scraper_lambda_function_name": "onoffmix_contest_scraper"
         },
+        "ONOFFMIX_HACKATHON": {
+            "type_name": "ONOFFMIX_HACKATHON",
+            "korean_name": "온오프믹스 해커톤 공지",
+            "url": "https://onoffmix.com/event/main?s=%ED%95%B4%EC%BB%A4%ED%86%A4",
+            "scraper_class_name": "OnoffmixHackathonScraper",
+            "scraper_lambda_function_name": "onoffmix_hackathon_scraper"
+        },
         "WEVITY_CONTEST": {
             "type_name": "WEVITY_CONTEST",
             "korean_name": "위비티 공모전 공지",

--- a/prompt/DYNAMIC_SCRAPER_CREATION_PROMPT.md
+++ b/prompt/DYNAMIC_SCRAPER_CREATION_PROMPT.md
@@ -1,0 +1,39 @@
+### 입력값
+
+```
+url: {url}
+example_html_file: {example_html_file}
+scraper_type_name: {scraper_type_name}
+scraper_type_korean_name: {scraper_type_korean_name}
+scraper_class_name: {scraper_class_name}
+scraper_lambda_function_name: {scraper_lambda_function_name}
+scraper_category_name: {scraper_category_name}
+scraper_category_korean_name: {scraper_category_korean_name}
+```
+
+### 수행 절차
+
+1. {url}에 대해 @library_general_handler.py의 구조를 차용하여 playwright를 활용한 동적 웹페이지 스크래핑 람다 펑션을 만들어라. 이때 파싱 대상이 되는 엘리먼트는 @example.html를 참고하라. 특히 DB에 저장되는 notice 형식은 기존의 것을 반드시 준용하라.
+
+2. 아래 내용으로 @scraper_types.json  을 업데이트 하라. 
+
+    "{scraper_type_name}": {
+        "type_name": "{scraper_type_name}",
+        "korean_name": "{scraper_type_korean_name}",
+        "url": "{url}",
+        "scraper_class_name": "{scraper_class_name}",
+        "scraper_lambda_function_name": "{scraper_lambda_function_name}"
+    }
+
+3. 아래 내용으로 @scraper_categories.json를 업데이트 하라.
+
+    "{scraper_category_name}": {
+        "korean_name": "{scraper_category_korean_name}",
+        "scraper_types": [
+            "{scraper_type_name}"
+        ]
+    }
+
+4. 멀티 스테이지 빌드에 맞게 @Dockerfile를 수정하고, @serverless.yml을 적절히 수정하라. 
+
+5. @build-images.sh 로 빌드해보고 @DOCKER_BUILD_AND_TEST_GUIDE.md 를 참고하여 로컬 테스트를 수행하라. 이때 docker logs 명령을 수행하지 마라.

--- a/serverless.yml
+++ b/serverless.yml
@@ -24,6 +24,7 @@ custom:
   accountId: 558793517018
   libraryGeneralImage: library-general-${self:provider.stage}
   wevityContestImage: wevity-contest-${self:provider.stage}
+  onoffmixContestImage: onoffmix-contest-${self:provider.stage}
 
 package:
   individually: false
@@ -428,5 +429,13 @@ functions:
     name: ${self:provider.stage}-library_general_scraper
     image:
       uri: ${self:custom.accountId}.dkr.ecr.${self:provider.region}.amazonaws.com/${self:custom.ecrRepositoryName}:${self:custom.libraryGeneralImage}
+    timeout: 120
+    memorySize: 1536
+
+  # 🐳 Onoffmix Contest 스크래퍼 (Container Image 사용 - Playwright 지원)
+  onoffmix_contest_scraper:
+    name: ${self:provider.stage}-onoffmix_contest_scraper
+    image:
+      uri: ${self:custom.accountId}.dkr.ecr.${self:provider.region}.amazonaws.com/${self:custom.ecrRepositoryName}:${self:custom.onoffmixContestImage}
     timeout: 120
     memorySize: 1536

--- a/serverless.yml
+++ b/serverless.yml
@@ -25,6 +25,7 @@ custom:
   libraryGeneralImage: library-general-${self:provider.stage}
   wevityContestImage: wevity-contest-${self:provider.stage}
   onoffmixContestImage: onoffmix-contest-${self:provider.stage}
+  onoffmixHackathonImage: onoffmix-hackathon-${self:provider.stage}
 
 package:
   individually: false
@@ -437,5 +438,13 @@ functions:
     name: ${self:provider.stage}-onoffmix_contest_scraper
     image:
       uri: ${self:custom.accountId}.dkr.ecr.${self:provider.region}.amazonaws.com/${self:custom.ecrRepositoryName}:${self:custom.onoffmixContestImage}
+    timeout: 120
+    memorySize: 1536
+
+  # 🐳 Onoffmix Hackathon 스크래퍼 (Container Image 사용 - Playwright 지원)
+  onoffmix_hackathon_scraper:
+    name: ${self:provider.stage}-onoffmix_hackathon_scraper
+    image:
+      uri: ${self:custom.accountId}.dkr.ecr.${self:provider.region}.amazonaws.com/${self:custom.ecrRepositoryName}:${self:custom.onoffmixHackathonImage}
     timeout: 120
     memorySize: 1536


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added scrapers for OnOffMix contests and hackathons, including deployment-ready Lambda functions.
  - Expanded contest category to include OnOffMix types for broader event coverage.
- Refactor
  - Centralized browser setup and date filtering into shared utilities, reducing duplication and improving consistency across scrapers.
  - Updated existing scrapers to use the new common utilities and recent-item lookups.
- Documentation
  - Introduced a dynamic scraper creation guide to streamline adding new sources.
- Chores
  - Updated Docker and Serverless configurations to support new containerized scrapers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->